### PR TITLE
ASM ModuleNode bug work around.

### DIFF
--- a/src/main/java/codes/rafael/asmjdkbridge/JdkClassWriter.java
+++ b/src/main/java/codes/rafael/asmjdkbridge/JdkClassWriter.java
@@ -62,6 +62,7 @@ public class JdkClassWriter extends ClassVisitor {
     }));
 
     private byte[] bytes;
+    private WritingModuleVisitor incompleteModuleVisitor;
 
     public JdkClassWriter(int flags) {
         this(flags, null);
@@ -113,7 +114,9 @@ public class JdkClassWriter extends ClassVisitor {
 
     @Override
     public ModuleVisitor visitModule(String name, int access, String version) {
-        return new WritingModuleVisitor(name, access, version);
+        assert this.incompleteModuleVisitor == null;
+        this.incompleteModuleVisitor = new WritingModuleVisitor(name, access, version);
+        return this.incompleteModuleVisitor;
     }
 
     class WritingModuleVisitor extends ModuleVisitor {
@@ -205,6 +208,7 @@ public class JdkClassWriter extends ClassVisitor {
 
         @Override
         public void visitEnd() {
+            JdkClassWriter.this.incompleteModuleVisitor = null;
             classConsumers.add(classBuilder -> {
                 classBuilder.with(ModuleAttribute.of(
                         ModuleDesc.of(name),
@@ -1068,6 +1072,9 @@ public class JdkClassWriter extends ClassVisitor {
 
     @Override
     public void visitEnd() {
+        if (incompleteModuleVisitor != null) {
+            incompleteModuleVisitor.visitEnd();
+        }
         ClassFile classFile;
         if ((flags & ClassWriter.COMPUTE_FRAMES) == 0) {
             classFile = ClassFile.of(ClassFile.DeadCodeOption.KEEP_DEAD_CODE, ClassFile.StackMapsOption.DROP_STACK_MAPS);


### PR DESCRIPTION
If a module-info ClassNode accepts an AsmJdkWriter no module info is added to the class file.

ASM's ModuleNode has a bug - it does not call ModuleVisitor.visitEnd().

Fix will call ModuleVisitor,visitEnd  at ClassVisitor.visitEnd if there is a ModuleVisitor outstanding.